### PR TITLE
Do not change the D-Bus interface name

### DIFF
--- a/src/libkolibri_daemon_dbus/kolibri-daemon-dbus-utils.c
+++ b/src/libkolibri_daemon_dbus/kolibri-daemon-dbus-utils.c
@@ -118,7 +118,7 @@ kolibri_daemon_get_default_bus_type(void)
     }
   else if (use_system_instance && local_kolibri_exists())
     {
-      g_log(G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE, "Local Kolibri data already exists, so ignoring KOLIBRI_USE_SYSTEM_INSTANCE");
+      g_log(G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE, "Local Kolibri data already exists, so ignoring " PROFILE_ENV_PREFIX "USE_SYSTEM_INSTANCE");
       return G_BUS_TYPE_SESSION;
     }
   else if (use_system_instance)

--- a/src/libkolibri_daemon_dbus/kolibri-daemon-dbus-utils.c
+++ b/src/libkolibri_daemon_dbus/kolibri-daemon-dbus-utils.c
@@ -118,7 +118,7 @@ kolibri_daemon_get_default_bus_type(void)
     }
   else if (use_system_instance && local_kolibri_exists())
     {
-      g_log(G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE, "Local Kolibri data already exists, so ignoring " PROFILE_ENV_PREFIX "USE_SYSTEM_INSTANCE");
+      g_log(G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE, "Local Kolibri data already exists, so ignoring KOLIBRI_USE_SYSTEM_INSTANCE");
       return G_BUS_TYPE_SESSION;
     }
   else if (use_system_instance)

--- a/src/libkolibri_daemon_dbus/meson.build
+++ b/src/libkolibri_daemon_dbus/meson.build
@@ -25,22 +25,17 @@ common_dependencies = [
     gobject_dep
 ]
 
-
 kolibri_daemon_dbus_src = gnome.gdbus_codegen(
     'kolibri-daemon-dbus',
-    sources: configure_file(
-        input: 'org.learningequality.Kolibri.Daemon.xml.in',
-        output: '@0@.xml'.format(daemon_application_id),
-        configuration: kolibri_app_config
-    ),
-    interface_prefix: '@0@.'.format(base_application_id),
+    sources: 'org.learningequality.Kolibri.Daemon.xml',
+    interface_prefix: 'org.learningequality.Kolibri.',
     namespace: 'Kolibri',
     # The public interface should be "org.learningequality.Kolibri.Daemon.Main",
     # but at the moment it appears as "org.learningequality.Kolibri.Daemon" for
     # compatibility with eos-kolibri's included D-Bus policy:
     # <https://github.com/endlessm/eos-kolibri>
     annotations: [
-        ['@0@'.format(daemon_application_id), 'org.gtk.GDBus.C.Name', 'DaemonMain']
+        ['org.learningequality.Kolibri.Daemon', 'org.gtk.GDBus.C.Name', 'DaemonMain']
     ],
     autocleanup: 'all'
 )

--- a/src/libkolibri_daemon_dbus/org.learningequality.Kolibri.Daemon.xml
+++ b/src/libkolibri_daemon_dbus/org.learningequality.Kolibri.Daemon.xml
@@ -2,7 +2,7 @@
  '-//freedesktop//DTD D-BUS Object Introspection 1.0//EN'
  'http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd'>
 <node>
-  <interface name="@DAEMON_APPLICATION_ID@">
+  <interface name="org.learningequality.Kolibri.Daemon">
     <method name="Hold" />
     <method name="Release" />
     <method name="Start" />
@@ -26,7 +26,7 @@
     <property name="Status" type="s" access="read" />
     <property name="Version" type="u" access="read" />
   </interface>
-  <interface name="@DAEMON_APPLICATION_ID@.Private">
+  <interface name="org.learningequality.Kolibri.Daemon.Private">
     <method name="CheckLoginToken">
       <arg direction="in" type="s" name="token" />
       <arg direction="out" type="a{sv}" name="details" />


### PR DESCRIPTION
Revert part of https://github.com/endlessm/endless-key-flatpak/pull/11.

For simplicity, the Endless Key app's version of kolibri-daemon should continue to use the org.learningequality.Kolibri prefix for its D-Bus interface names. The interface itself should be identical to upstream.