### PR TITLE
Add github workflow to lint and build flatpak bundle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,77 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Run pre-commit hooks
+        uses: pre-commit/action@v3.0.0
+
+  flatpak:
+    name: Flatpak
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install \
+            flatpak \
+            flatpak-builder \
+            xvfb
+
+      - name: Cache flatpak user installation
+        uses: actions/cache@v3
+        with:
+          path: ~/.local/share/flatpak
+          key: flatpak-user-${{ runner.arch }}
+
+      - name: Cache flatpak-builder state directory
+        uses: actions/cache@v3
+        with:
+          path: .flatpak-builder
+          key: flatpak-builder-${{ runner.arch }}
+
+      - name: Add Flathub repository
+        run: |
+          flatpak remote-add --user --if-not-exists flathub \
+            https://dl.flathub.org/repo/flathub.flatpakrepo
+
+      - name: Build flatpak
+        # The build needs to be run under Xvfb (or some other virtual
+        # display server) so that Gdk initialization succeeds in the
+        # tests.
+        run: |
+          xvfb-run --auto-servernum -- \
+            flatpak-builder --user --install-deps-from=flathub --repo _repo _flatpak \
+            build-aux/flatpak/org.endlessos.Key.Devel.json
+
+      - name: Create flatpak bundle
+        run: |
+          flatpak build-bundle _repo endless-key-devel.flatpak org.endlessos.Key.Devel
+
+      - name: Upload flatpak bundle
+        uses: actions/upload-artifact@v3
+        with:
+          name: flatpak
+          path: endless-key-devel.flatpak

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 __pycache__
 
+# Meson build
 /build
+
+# Flatpak build
+.flatpak-builder/
+_flatpak/
+_repo/
+*.flatpak

--- a/src/kolibri_gnome/application.py
+++ b/src/kolibri_gnome/application.py
@@ -7,7 +7,6 @@ from gettext import gettext as _
 from urllib.parse import urlsplit
 
 from gi.repository import Adw
-from gi.repository import Gdk
 from gi.repository import Gio
 from gi.repository import GLib
 from gi.repository import GObject

--- a/src/kolibri_gnome/kolibri_webview.py
+++ b/src/kolibri_gnome/kolibri_webview.py
@@ -69,14 +69,14 @@ class KolibriWebView(WebKit.WebView):
         self, gesture: Gtk.GestureClick, n_press: int, x: int, y: int
     ) -> bool:
         self.go_back()
-        gesture.set_state(Gtk.EventSequenceState.CLAIMED);
+        gesture.set_state(Gtk.EventSequenceState.CLAIMED)
         return True
 
     def __on_forward_button_pressed(
         self, gesture: Gtk.GestureClick, n_press: int, x: int, y: int
     ) -> bool:
         self.go_forward()
-        gesture.set_state(Gtk.EventSequenceState.CLAIMED);
+        gesture.set_state(Gtk.EventSequenceState.CLAIMED)
         return True
 
     def __continue_load_kolibri_url(self):


### PR DESCRIPTION
This makes sure the linting is run for pull requests and builds the flatpak as a bundle. That will make testing much easier prior to its existence on Flathub.