### PR TITLE
Roll version number back to 0.1

### DIFF
--- a/data/metainfo/org.endlessos.Key.metainfo.xml.in.in
+++ b/data/metainfo/org.endlessos.Key.metainfo.xml.in.in
@@ -22,17 +22,9 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="1.0.0" date="2023-09-05" type="stable">
+    <release version="0.1" date="2023-09-05" type="stable">
       <description>
-        <p>Changes included in this release:</p>
-        <ul>
-          <li>
-            Forked from kolibri-installer-gnome v2.3.3
-          </li>
-          <li>
-            Use Endless Key flavor configuration and scheme.
-          </li>
-        </ul>
+        <p>This is the initial release of Endless Key.</p>
       </description>
     </release>
   </releases>

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('kolibri-gnome', ['c'],
     meson_version: '>= 0.56.0',
-    version: '2.3.3'
+    version: '0.1'
 )
 
 package_string = '@0@-@1@'.format(meson.project_name(), meson.project_version())


### PR DESCRIPTION
This app is not ready for consumption yet, so I don't think we should be calling it 1.0.0. Furthermore, since this is an app and not a library providing an API, I don't think there's a good reason to have micro level releases. Probably it would be fine just to have integer releases, but I think we may want to reserve a major version for when there are larger breaks such as depending on new GNOME or Kolibri series.

This also fixes the project version declared to meson, which still had the kolibri-installer-gnome version. When released, I expect to use `vX.Y` tags.