### PR TITLE
metainfo: Use appstreamcli to validate, rather than appstream-util

### DIFF
--- a/build-aux/flatpak/org.endlessos.Key.Devel.json
+++ b/build-aux/flatpak/org.endlessos.Key.Devel.json
@@ -65,9 +65,15 @@
             ],
             "sources" : [
                 {
-                    "type" : "git",
-                    "url" : "https://github.com/endlessm/endless-key-flatpak.git",
-                    "branch" : "main"
+                    "type" : "dir",
+                    "path" : "../..",
+                    "skip" : [
+                        ".git",
+                        ".flatpak-builder",
+                        "build",
+                        "flatpak_app",
+                        "repo"
+                    ]
                 }
             ]
         }

--- a/data/metainfo/meson.build
+++ b/data/metainfo/meson.build
@@ -13,12 +13,27 @@ metainfo_file = i18n.merge_file(
     install_dir: metainfo_dir
 )
 
-appstream_util = find_program('appstream-util', required: false)
+appstreamcli = find_program('appstreamcli', required: false)
 
-if appstream_util.found()
+if appstreamcli.found()
+    # FIXME: We have to temporarily remove the desktop ID from the metainfo
+    # file, as until https://github.com/ximion/appstream/pull/522 is shipped,
+    # appstreamcli won’t accept `endless` as a desktop ID.
+    metainfo_file_for_validation = custom_target(
+        'org.endlessos.Key.Temp.metainfo.xml',
+        output: 'org.endlessos.Key.Temp.metainfo.xml',
+        input: metainfo_file,
+        command: [
+            'sed',
+            's|<compulsory_for_desktop>endless</compulsory_for_desktop>||g',
+            '@INPUT@',
+        ],
+        capture: true,
+    )
+
     test(
         'Validate metainfo file',
-        appstream_util,
-        args: ['validate', '--nonet', metainfo_file]
+        appstreamcli,
+        args: ['validate', '--no-net', '--explain', metainfo_file_for_validation]
     )
 endif

--- a/data/metainfo/org.endlessos.Key.metainfo.xml.in.in
+++ b/data/metainfo/org.endlessos.Key.metainfo.xml.in.in
@@ -42,7 +42,7 @@
       <image type="source" width="1800" height="1013">https://raw.githubusercontent.com/endlessm/endless-key-flatpak/main/data/screenshots/1-equity.png</image>
     </screenshot>
     <screenshot>
-      <caption>Works online and offline; access learning resources for coding, STEM, cooking, and arts &amp; crafts! Videos, games, and activities included. No Internet required!</caption>
+      <caption>Works online and offline; access learning resources for coding, STEM, cooking, and arts &amp; crafts!</caption>
       <image type="source" width="1800" height="1013">https://raw.githubusercontent.com/endlessm/endless-key-flatpak/main/data/screenshots/2-offline.png</image>
     </screenshot>
     <screenshot>
@@ -50,11 +50,11 @@
       <image type="source" width="1800" height="1013">https://raw.githubusercontent.com/endlessm/endless-key-flatpak/main/data/screenshots/3-tiles.png</image>
     </screenshot>
     <screenshot>
-      <caption>Engaging and interactive; discover an abundance of ready-made resources, interactive games, simulations, and a vast ocean of curated content.</caption>
+      <caption>Engaging and interactive; discover an abundance of ready-made resources, games, simulations, etc.</caption>
       <image type="source" width="1800" height="1013">https://raw.githubusercontent.com/endlessm/endless-key-flatpak/main/data/screenshots/4-interactive.png</image>
     </screenshot>
     <screenshot>
-      <caption>Completely free; access without an account, safeguarded data, no ads, and no third-party involvement.</caption>
+      <caption>Completely free; access without an account, safeguarded data, and no ads.</caption>
       <image type="source" width="1800" height="1013">https://raw.githubusercontent.com/endlessm/endless-key-flatpak/main/data/screenshots/5-free.png</image>
     </screenshot>
     <screenshot>


### PR DESCRIPTION
appstream-util comes from libappstream-glib, which is outdated and
unmaintained. appstreamcli is the more modern replacement, and it comes
from libappstream.

It implements more up to date validation rules, in particular it has
raised the maximum length of screenshot captions from 50 characters to a
more manageable 100 characters.

The downside is that it more strictly validates
`<compulsory_for_desktop>`, and rejects ‘endless’ because it’s not
officially registered as a desktop ID. Work around that for now by
temporarily removing that element from the XML during validation. In the
long term, we need to register the ID:
https://github.com/ximion/appstream/pull/522.

Signed-off-by: Philip Withnall <philip@tecnocode.co.uk>