### PR TITLE
app: Allow XDG_CURRENT_DESKTOP with either capitalisation

### DIFF
--- a/data/metainfo/org.endlessos.Key.metainfo.xml.in.in
+++ b/data/metainfo/org.endlessos.Key.metainfo.xml.in.in
@@ -72,5 +72,5 @@
   <content_rating type="oars-1.1" />
   <update_contact>info_at_learningequality.org</update_contact>
   <translation type="gettext">kolibri-gnome</translation>
-  <compulsory_for_desktop>endless</compulsory_for_desktop>
+  <compulsory_for_desktop>Endless</compulsory_for_desktop>
 </component>

--- a/src/kolibri_gnome/application.py
+++ b/src/kolibri_gnome/application.py
@@ -148,8 +148,9 @@ class Application(Adw.Application):
         window.connect("open-new-window", self.__window_on_open_new_window)
         window.load_kolibri_url(target_url, present=True)
 
-        # Maximize windows on Endless OS
-        if XDG_CURRENT_DESKTOP == "endless:GNOME":
+        # Maximize windows on Endless OS. Typically $XDG_CURRENT_DESKTOP will be
+        # `endless:GNOME` or `Endless:GNOME`.
+        if XDG_CURRENT_DESKTOP and "endless" in XDG_CURRENT_DESKTOP.lower().split(":"):
             window.maximize()
 
         window.connect("auto-close", self.__kolibri_window_on_auto_close)


### PR DESCRIPTION
Previously the desktop ID defined by Endless OS was `endless`. However, we are now trying to standardise it, and it would be neater for it to be `Endless`. Allow both cases of ID in the code, to allow for any eventuality.

Strictly, this should be a case-sensitive comparison, but it seems unlikely that someone else is going to claim `endless` in future.

See: https://gitlab.freedesktop.org/xdg/xdg-specs/-/merge_requests/73