### PR TITLE
Build AppStream for metainfo validation

### DIFF
--- a/build-aux/flatpak/modules/AppStream.json
+++ b/build-aux/flatpak/modules/AppStream.json
@@ -1,0 +1,22 @@
+{
+    "name" : "AppStream",
+    "buildsystem" : "meson",
+    "config-opts" : [
+        "-Dstemming=false",
+        "-Dsystemd=false",
+        "-Dgir=false",
+        "-Dapidocs=false",
+        "-Dinstall-docs=false"
+    ],
+    "cleanup" : [
+        "*"
+    ],
+    "sources" : [
+        {
+            "type": "archive",
+            "url": "https://freedesktop.org/software/appstream/releases/AppStream-0.16.3.tar.xz",
+            "sha256": "081c917646e94d7221c9e4aae54dacda95a27c607fa93cd8e6344a2b318b98b1",
+            "strip-components": 2
+        }
+    ]
+}

--- a/build-aux/flatpak/modules/libxmlb.json
+++ b/build-aux/flatpak/modules/libxmlb.json
@@ -1,0 +1,20 @@
+{
+    "name" : "libxmlb",
+    "buildsystem" : "meson",
+    "config-opts" : [
+        "-Dgtkdoc=false",
+        "-Dintrospection=false",
+        "-Dcli=false",
+        "-Dzstd=false"
+    ],
+    "cleanup" : [
+        "*"
+    ],
+    "sources" : [
+        {
+            "type" : "archive",
+            "url" : "https://github.com/hughsie/libxmlb/releases/download/0.3.14/libxmlb-0.3.14.tar.xz",
+            "sha256" : "a2f0056eed14ff791aee2b08b1514a0f1b6cf215f0579138a8cae8c45a0d3b0f"
+        }
+    ]
+}

--- a/build-aux/flatpak/modules/yaml.json
+++ b/build-aux/flatpak/modules/yaml.json
@@ -1,0 +1,14 @@
+{
+    "name" : "yaml",
+    "buildsystem" : "autotools",
+    "cleanup" : [
+        "*"
+    ],
+    "sources" : [
+        {
+            "type" : "archive",
+            "url" : "http://pyyaml.org/download/libyaml/yaml-0.2.5.tar.gz",
+            "sha256" : "c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4"
+        }
+    ]
+}

--- a/build-aux/flatpak/org.endlessos.Key.Devel.json
+++ b/build-aux/flatpak/org.endlessos.Key.Devel.json
@@ -45,6 +45,9 @@
     },
     "modules" : [
         "modules/iproute2.json",
+        "modules/libxmlb.json",
+        "modules/yaml.json",
+        "modules/AppStream.json",
         "modules/python3-markdown.json",
         "modules/python3-kolibri.json",
         "modules/python3-kolibri-pytz.json",


### PR DESCRIPTION
Since the metainfo validation was switched to using `appstreamcli` in 83878b3a493d93d29f661f0987fefac800e7adf0, it's not actually being run during the flatpak build since `appstreamcli` isn't included in the GNOME 44 runtime.

That will change with the GNOME 45 runtime, but in the meantime build AppStream and it's dependencies during the flatpak build. Since these are only test dependencies, all of their files can be cleaned up. Once the flatpak is switched to the GNOME 45 runtime, this commit should be reverted.