### PR TITLE
Drop using X11

### DIFF
--- a/build-aux/flatpak/org.endlessos.Key.Devel.json
+++ b/build-aux/flatpak/org.endlessos.Key.Devel.json
@@ -12,7 +12,6 @@
         "--socket=fallback-x11",
         "--socket=pulseaudio",
         "--socket=wayland",
-        "--socket=x11",
         "--system-talk-name=org.endlessos.Key.Devel.Daemon",
         "--env=KOLIBRI_HOME=~/.var/app/org.endlessos.Key.Devel/data/kolibri",
         "--env=KOLIBRI_HTTP_PORT=0",


### PR DESCRIPTION
Wayland is the default windows environment. X11 has been set as the fallback by "--socket=fallback-x11". So, drop duplicated "--socket=x11" permission settings.