### PR TITLE
Drop ending dot of Caption objects

### DIFF
--- a/data/metainfo/org.endlessos.Key.metainfo.xml.in.in
+++ b/data/metainfo/org.endlessos.Key.metainfo.xml.in.in
@@ -50,11 +50,11 @@
       <image type="source" width="1800" height="1013">https://raw.githubusercontent.com/endlessm/endless-key-flatpak/main/data/screenshots/3-tiles.png</image>
     </screenshot>
     <screenshot>
-      <caption>Engaging and interactive; discover an abundance of ready-made resources, games, simulations, etc.</caption>
+      <caption>Engaging and interactive; discover an abundance of ready-made resources, games, simulations, etc</caption>
       <image type="source" width="1800" height="1013">https://raw.githubusercontent.com/endlessm/endless-key-flatpak/main/data/screenshots/4-interactive.png</image>
     </screenshot>
     <screenshot>
-      <caption>Completely free; access without an account, safeguarded data, and no ads.</caption>
+      <caption>Completely free; access without an account, safeguarded data, and no ads</caption>
       <image type="source" width="1800" height="1013">https://raw.githubusercontent.com/endlessm/endless-key-flatpak/main/data/screenshots/5-free.png</image>
     </screenshot>
     <screenshot>


### PR DESCRIPTION
Validate AppData file failed on Flathub, because metainfo's <caption> objects cannot end in '.'.
```
flatpak run --env=G_DEBUG=fatal-criticals --command=appstream-util org.flatpak.Builder validate builddir/*/share/appdata/org.endlessos.Key.appdata.xml
 in dir /srv/buildbot/worker/build-x86_64-5/build (timeout 1200 secs)
 watching logfiles {}
 argv: b'flatpak run --env=G_DEBUG=fatal-criticals --command=appstream-util org.flatpak.Builder validate builddir/*/share/appdata/org.endlessos.Key.appdata.xml'
 using PTY: False
builddir/files/share/appdata/org.endlessos.Key.appdata.xml: FAILED:
• style-invalid         : <caption> cannot end in '.' [Completely free; access without an account, safeguarded data, and no ads.]
• style-invalid         : <caption> cannot end in '.' [Engaging and interactive; discover an abundance of ready-made resources, games, simulations, etc.]
Validation of files failed
```

So, drop the ending dots.

Fixes: https://github.com/endlessm/endless-key-flatpak/issues/46