### PR TITLE
Release v0.3

### DIFF
--- a/data/metainfo/org.endlessos.Key.metainfo.xml.in.in
+++ b/data/metainfo/org.endlessos.Key.metainfo.xml.in.in
@@ -63,6 +63,13 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="0.3" date="2023-09-13" type="stable">
+      <description>
+        <ul>
+          <li>Fix application information</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.2" date="2023-09-12" type="stable">
       <description>
         <ul>


### PR DESCRIPTION
This is blocked by https://github.com/endlessm/endless-key-flatpak/pull/48.

This helps [Add org.endlessos.Key](https://github.com/flathub/flathub/pull/4481) for [Publish the Endless Key app on Flathub](https://github.com/endlessm/endless-key-flatpak/issues/5).