### PR TITLE
Change the development build name suffix to "(Dev)"

### DIFF
--- a/build-aux/flatpak/org.endlessos.Key.Devel.json
+++ b/build-aux/flatpak/org.endlessos.Key.Devel.json
@@ -4,7 +4,7 @@
     "runtime-version" : "44",
     "sdk" : "org.gnome.Sdk",
     "command" : "/app/bin/kolibri-gnome",
-    "desktop-file-name-suffix" : " ☢️",
+    "desktop-file-name-suffix" : " (Dev)",
     "finish-args" : [
         "--device=dri",
         "--share=ipc",


### PR DESCRIPTION
The previous "☢️" suffix was considered to be too alarming.

Closes: https://github.com/endlessm/endless-key-flatpak/issues/51