### PR TITLE
In automatic_provision.json, ensure language_id is unset

### DIFF
--- a/src/kolibri_daemon/kolibri_utils.py
+++ b/src/kolibri_daemon/kolibri_utils.py
@@ -127,7 +127,11 @@ def _get_automatic_provision_data():
             "learner_can_login_with_no_password": False,
         },
         "device_settings": {
-            "language_id": None,
+            # Kolibri interprets None as "the system language at setup time",
+            # while an empty string causes Kolibri to always use the current
+            # browser language:
+            # <https://github.com/learningequality/kolibri/issues/11248>
+            "language_id": "",
             "landing_page": "learn",
             "allow_guest_access": False,
             "allow_other_browsers_to_connect": False,


### PR DESCRIPTION
Kolibri quietly ignores language_id when it is set to None, and defaults to the current system language. Instead, for language_id to actually be unset, we will set it to an empty string. This causes Kolibri to serve pages using each client's default language.

This is a workaround for https://github.com/learningequality/kolibri/issues/11248.

Closes: https://github.com/endlessm/endless-key-flatpak/issues/57