### PR TITLE
Default KOLIBRI_HOME to $XDG_HOME/kolibri

### DIFF
--- a/build-aux/flatpak/org.endlessos.Key.Devel.json
+++ b/build-aux/flatpak/org.endlessos.Key.Devel.json
@@ -13,7 +13,6 @@
         "--socket=pulseaudio",
         "--socket=wayland",
         "--system-talk-name=org.endlessos.Key.Devel.Daemon",
-        "--env=KOLIBRI_HOME=~/.var/app/org.endlessos.Key.Devel/data/kolibri",
         "--env=KOLIBRI_HTTP_PORT=0",
         "--env=PYTHONPATH=/app/kolibri-plugins/lib/python",
         "--env=KOLIBRI_APPS_BUNDLE_PATH=/app/share/endless-key/apps-bundle",

--- a/src/kolibri_app/globals.py
+++ b/src/kolibri_app/globals.py
@@ -24,13 +24,22 @@ APP_DISABLE_AUTOMATIC_PROVISION = os.environ.get(
 
 XDG_CURRENT_DESKTOP = os.environ.get("XDG_CURRENT_DESKTOP")
 
-# Logic for KOLIBRI_HOME is from kolibri.utils.conf. We avoid importing it from
-# Kolibri because the import comes with side-effects.
-DEFAULT_KOLIBRI_HOME_PATH = Path.home().joinpath(".kolibri")
+# Logic for KOLIBRI_HOME that mimics kolibri.utils.conf except that
+# $XDG_DATA_HOME/kolibri is used rather than ~/.kolibri so that the home
+# directory doesn't need to be exposed in the flatpak.
+if "XDG_DATA_HOME" in os.environ:
+    XDG_DATA_HOME = Path(os.environ["XDG_DATA_HOME"]).expanduser().absolute()
+else:
+    XDG_DATA_HOME = Path.home().joinpath(".local/share")
+DEFAULT_KOLIBRI_HOME_PATH = XDG_DATA_HOME.joinpath("kolibri")
 if "KOLIBRI_HOME" in os.environ:
     KOLIBRI_HOME_PATH = Path(os.environ["KOLIBRI_HOME"]).expanduser().absolute()
 else:
     KOLIBRI_HOME_PATH = DEFAULT_KOLIBRI_HOME_PATH
+
+    # Set KOLIBRI_HOME now so that kolibri's initialization doesn't set
+    # it back to ~/.kolibri.
+    os.environ["KOLIBRI_HOME"] = KOLIBRI_HOME_PATH.as_posix()
 
 
 def init_gettext():

--- a/src/libkolibri_daemon_dbus/kolibri-daemon-dbus-utils.c
+++ b/src/libkolibri_daemon_dbus/kolibri-daemon-dbus-utils.c
@@ -65,7 +65,7 @@ kolibri_home_dir(void)
   g_autofree gchar *kolibri_home = expanduser(g_getenv("KOLIBRI_HOME"));
 
   if (kolibri_home == NULL || kolibri_home[0] == '\0')
-    return g_build_path("/", g_get_home_dir(), ".kolibri", NULL);
+    return g_build_path("/", g_get_user_data_dir(), "kolibri", NULL);
 
   return g_steal_pointer(&kolibri_home);
 }


### PR DESCRIPTION
Upstream Kolibri defaults `KOLIBRI_HOME` to `~/.kolibri`, but in the Flatpak context it's much better to use `$XDG_HOME/kolibri` (`~/.local/share/kolibri` by default) so that the home directory doesn't need to be exposed in the sandbox. Currently we're setting that via the Flatpak finish args, but it's cleaner to handle that in the code as suggested by a Flathub developer.