### PR TITLE
Metainfo: Add numbers to the screenshot captions

### DIFF
--- a/data/metainfo/org.endlessos.Key.metainfo.xml.in.in
+++ b/data/metainfo/org.endlessos.Key.metainfo.xml.in.in
@@ -38,27 +38,27 @@
   <launchable type="desktop-id">@FRONTEND_APPLICATION_ID@.desktop</launchable>
   <screenshots>
     <screenshot type="default">
-      <caption>Bring equity into the classroom; curated learning anywhere, anytime with Endless Key</caption>
+      <caption>1. Bring equity into the classroom; curated learning anywhere, anytime with Endless Key</caption>
       <image type="source" width="1800" height="1013">https://raw.githubusercontent.com/endlessm/endless-key-flatpak/main/data/screenshots/1-equity.png</image>
     </screenshot>
     <screenshot>
-      <caption>Works online and offline; access learning resources for coding, STEM, cooking, and arts &amp; crafts!</caption>
+      <caption>2. Works online and offline; access learning resources for coding, STEM, cooking, and arts &amp; crafts!</caption>
       <image type="source" width="1800" height="1013">https://raw.githubusercontent.com/endlessm/endless-key-flatpak/main/data/screenshots/2-offline.png</image>
     </screenshot>
     <screenshot>
-      <caption>Resources such as finance, healthy body, TED Ed, sports, games, arts &amp; crafts, gardening, and more</caption>
+      <caption>3. Resources such as finance, healthy body, TED Ed, sports, games, arts &amp; crafts, gardening, and more</caption>
       <image type="source" width="1800" height="1013">https://raw.githubusercontent.com/endlessm/endless-key-flatpak/main/data/screenshots/3-tiles.png</image>
     </screenshot>
     <screenshot>
-      <caption>Engaging and interactive; discover an abundance of ready-made resources, games, simulations, etc</caption>
+      <caption>4. Engaging and interactive; discover an abundance of ready-made resources, games, simulations, etc</caption>
       <image type="source" width="1800" height="1013">https://raw.githubusercontent.com/endlessm/endless-key-flatpak/main/data/screenshots/4-interactive.png</image>
     </screenshot>
     <screenshot>
-      <caption>Completely free; access without an account, safeguarded data, and no ads</caption>
+      <caption>5. Completely free; access without an account, safeguarded data, and no ads</caption>
       <image type="source" width="1800" height="1013">https://raw.githubusercontent.com/endlessm/endless-key-flatpak/main/data/screenshots/5-free.png</image>
     </screenshot>
     <screenshot>
-      <caption>Grades 5–9, 2700+ curated resources, 1500+ videos, 300+ e-books</caption>
+      <caption>6. Grades 5–9, 2700+ curated resources, 1500+ videos, 300+ e-books</caption>
       <image type="source" width="1800" height="1013">https://raw.githubusercontent.com/endlessm/endless-key-flatpak/main/data/screenshots/6-list.png</image>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
This could read _alright_ but it's secretly trying to work around https://github.com/flathub/linux-store-frontend/issues/80 (which appears to still be an issue on the new front-end) and https://github.com/endlessm/endless-key-flatpak/issues/50.