### PR TITLE
Prepare release notes for 0.6

### DIFF
--- a/data/metainfo/org.endlessos.Key.metainfo.xml.in.in
+++ b/data/metainfo/org.endlessos.Key.metainfo.xml.in.in
@@ -63,6 +63,15 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="0.6" date="2023-09-21" type="stable">
+      <description>
+        <ul>
+          <li>The loading screen shown during startup has been improved.</li>
+          <li>The content downloaded during first launch can now be selected.</li>
+          <li>An initial Spanish translation has been added.</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.5" date="2023-09-18" type="stable">
       <description>
         <ul>


### PR DESCRIPTION
These are primarily changes in the explore plugin that will be available in the flatpak for the first time.

Helps: #82