### PR TITLE
ci: Workaround f-e-d-c git safe.directory handling

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -27,4 +27,12 @@ jobs:
           EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: --update --verbose --never-fork build-aux/flatpak/org.endlessos.Key.Devel.json
+          # The f-e-d-c safe.directory handling is currently broken when
+          # the manifest is in a subdirectory.
+          #
+          # https://github.com/flathub/flatpak-external-data-checker/issues/386
+          entrypoint: /bin/bash
+          args: >-
+            -c 'git config --global --add safe.directory "$PWD" &&
+            /app/flatpak-external-data-checker --update --verbose --never-fork
+            build-aux/flatpak/org.endlessos.Key.Devel.json'


### PR DESCRIPTION
Currently flatpak-external-data-checker assumes that the manifest is in the root of the git checkout and marks that directory safe. That means the `.git` directory is not considered safe and commits can't be made in the container. Add a workaround until it's fixed upstream.

Fixes: #45