### PR TITLE
Update checker workaround #2

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -27,12 +27,4 @@ jobs:
           EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          # The f-e-d-c safe.directory handling is currently broken when
-          # the manifest is in a subdirectory.
-          #
-          # https://github.com/flathub/flatpak-external-data-checker/issues/386
-          entrypoint: /bin/bash
-          args: >-
-            -c 'git config --global --add safe.directory "$PWD" &&
-            /app/flatpak-external-data-checker --update --verbose --never-fork
-            build-aux/flatpak/org.endlessos.Key.Devel.json'
+          args: --update --verbose --never-fork build-aux/flatpak/org.endlessos.Key.Devel.json

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -7,17 +7,28 @@ on:
 jobs:
   flatpak-external-data-checker:
     runs-on: ubuntu-latest
+    container: ghcr.io/flathub/flatpak-external-data-checker:latest
 
     strategy:
       matrix:
         branch: [ main ] # list all branches to check
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
         with:
           ref: ${{ matrix.branch }}
 
-      - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
+      # The f-e-d-c safe.directory handling is currently broken when the
+      # manifest is in a subdirectory, so it has to be handled outside
+      # of the checker.
+      #
+      # https://github.com/flathub/flatpak-external-data-checker/issues/386
+      - name: Mark git checkout safe
+        run: |
+          git config --global --add safe.directory "$PWD"
+
+      - name: Run flatpak-external-data-checker
         env:
           GIT_AUTHOR_NAME: Flatpak External Data Checker
           GIT_COMMITTER_NAME: Flatpak External Data Checker
@@ -26,5 +37,6 @@ jobs:
           GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
           EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: --update --verbose --never-fork build-aux/flatpak/org.endlessos.Key.Devel.json
+        run: |
+          /app/flatpak-external-data-checker --update --verbose --never-fork \
+            build-aux/flatpak/org.endlessos.Key.Devel.json


### PR DESCRIPTION
Use the f-e-d-c image for the whole job container so that we can run steps normally inside it. That allows marking the git checkout as a safe directory without trying to push it through the entrypoint.

Fixes: #45