### PR TITLE
Fix markdown by x-checker-data's versions property

### DIFF
--- a/build-aux/flatpak/modules/iproute2.json
+++ b/build-aux/flatpak/modules/iproute2.json
@@ -10,11 +10,12 @@
         {
             "type" : "git",
             "url" : "https://git.kernel.org/pub/scm/network/iproute2/iproute2.git",
-            "tag" : "v5.7.0",
+            "tag" : "v6.5.0",
             "x-checker-data" : {
                 "type" : "git",
                 "tag-pattern" : "^v([\\d.]+)$"
-            }
+            },
+            "commit": "040325f543a1f7e6bb336355c136984e9bbe00d6"
         }
     ]
 }

--- a/build-aux/flatpak/modules/python3-kolibri-app-desktop-xdg-plugin.json
+++ b/build-aux/flatpak/modules/python3-kolibri-app-desktop-xdg-plugin.json
@@ -7,12 +7,15 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/90/d4/a7c9b6c5d176654aa3dbccbfd0be4fd3a263355dc24122a5f1937bdc2689/Pillow-8.3.2.tar.gz",
-            "sha256": "dde3f3ed8d00c72631bc19cbfff8ad3b6215062a5eed402381ad365f82f0c18c",
+            "url": "https://files.pythonhosted.org/packages/7d/2a/2fc11b54e2742db06297f7fa7f420a0e3069fdcf0e4b57dfec33f0b08622/Pillow-8.4.0.tar.gz",
+            "sha256": "b8e2f83c56e141920c39464b852de3719dfbfb6e3c99a2d8da0edf4fb33176ed",
             "x-checker-data": {
                 "type": "pypi",
                 "name": "Pillow",
-                "versions": {">=": "8.2.0", "<": "9.0.0"}
+                "versions": {
+                    ">=": "8.2.0",
+                    "<": "9.0.0"
+                }
             }
         },
         {

--- a/build-aux/flatpak/modules/python3-kolibri.json
+++ b/build-aux/flatpak/modules/python3-kolibri.json
@@ -8,14 +8,17 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://github.com/learningequality/kolibri/releases/download/v0.16.0-beta5/kolibri-0.16.0b5-py2.py3-none-any.whl",
-            "sha256": "3925b7a18b6684547fd50e1df7326ace318d9d81d1fa02317f1870e117eb515c",
+            "url": "https://github.com/learningequality/kolibri/releases/download/v0.16.0-beta6/kolibri-0.16.0b6-py2.py3-none-any.whl",
+            "sha256": "4be88f4caf83a3c9a2c805f407fef2146ce5a21f26c6ee6db9d8d7b8deb6aca0",
             "x-checker-data": {
                 "type": "json",
                 "url": "https://api.github.com/repos/learningequality/kolibri/releases",
                 "version-query": "first | .tag_name | sub(\"^[vV]\"; \"\") | sub(\"-beta\"; \"b\")",
                 "url-query": "first | .assets[] | select(.name==\"kolibri-\" + $version + \"-py2.py3-none-any.whl\") | .browser_download_url",
-                "versions": {">=": "0.16.0", "<": "0.17.0"}
+                "versions": {
+                    ">=": "0.16.0",
+                    "<": "0.17.0"
+                }
             }
         },
         {

--- a/build-aux/flatpak/modules/python3-markdown.json
+++ b/build-aux/flatpak/modules/python3-markdown.json
@@ -2,7 +2,7 @@
     "name": "python3-markdown",
     "buildsystem": "simple",
     "build-commands": [
-        "pip3 install --ignore-installed --no-deps --no-index --no-build-isolation --find-links=\"file://${PWD}\" --target=\"${KOLIBRI_MODULE_PATH}/dist/\" markdown==3.3.7"
+        "pip3 install --ignore-installed --no-deps --no-index --no-build-isolation --find-links=\"file://${PWD}\" --target=\"${KOLIBRI_MODULE_PATH}/dist/\" markdown"
     ],
     "sources": [
         {
@@ -12,7 +12,8 @@
             "x-checker-data": {
                 "type": "pypi",
                 "name": "Markdown",
-                "packagetype": "bdist_wheel"
+                "packagetype": "bdist_wheel",
+                "versions": {"==": "3.3.7"}
             }
         }
     ]


### PR DESCRIPTION
As mentioned in commit https://github.com/endlessm/endless-key-flatpak/commit/a0a32b8c7b4df23843330fb08c34bbd69f2504a4 ("Add python3-markdown to flatpak modules"), fix markdown's version, but with x-checker-data's versions property.

Helps: https://github.com/endlessm/endless-key-flatpak/issues/45