### PR TITLE
CI: Merge External Data Checker's successful PRs automatically

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -37,6 +37,7 @@ jobs:
           GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
           EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: build-aux/flatpak
         run: |
           /app/flatpak-external-data-checker --update --verbose --never-fork \
-            build-aux/flatpak/org.endlessos.Key.Devel.json
+            org.endlessos.Key.Devel.json

--- a/build-aux/flatpak/flathub.json
+++ b/build-aux/flatpak/flathub.json
@@ -1,0 +1,3 @@
+{
+    "automerge-flathubbot-prs": true
+}


### PR DESCRIPTION
Merge External Data Checker's successful PRs automatically by setting "automerge-flathubbot-prs" in flathub.json. However, flathub.json is placed in "build-aux/flatpak" folder aside of the manifest. So, change flatpak-external-data-checker to "build-aux/flatpak".

Fixes: https://github.com/endlessm/endless-key-flatpak/issues/45