### PR TITLE
Initialize Kolibri debug from KOLIBRI_DEBUG environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ component of the project's version number.
 
 ### Debugging and advanced usage
 
+#### Kolibri debug mode
+
+When Kolibri is run in debug mode, it uses debug logging for its modules
+and enables Django's debug mode. To enable Kolibri debug mode, start
+kolibri-daemon with the `KOLIBRI_DEBUG` environment variable set to `1`.
+
 #### Web inspector
 
 For development builds, kolibri-gnome enables WebKit developer extras. You can

--- a/src/kolibri_daemon/kolibri_utils.py
+++ b/src/kolibri_daemon/kolibri_utils.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from kolibri_app.config import ENDLESS_KEY_DATA_DIR
 from kolibri_app.globals import APP_AUTOMATIC_PROVISION
+from kolibri_app.utils import getenv_as_bool
 
 from .content_extensions_manager import ContentExtensionsManager
 
@@ -50,6 +51,12 @@ def init_kolibri(**kwargs):
 
     for plugin_name in OPTIONAL_PLUGINS:
         _enable_kolibri_plugin(plugin_name, optional=True)
+
+    # Use the KOLIBRI_DEBUG environment variable for the Kolibri debug
+    # initialization value. This is basically equivalent to how "kolibri
+    # start" works.
+    if "debug" not in kwargs:
+        kwargs["debug"] = getenv_as_bool("KOLIBRI_DEBUG", default=False)
 
     initialize(**kwargs)
 


### PR DESCRIPTION
If the `KOLIBRI_DEBUG` environment variable is set to a truthy value, pass `debug=True` to the Kolibri initialization routine. This enables debug logging and the Django debug mode. This is roughly equivalent to how `kolibri start` works since it treats `KOLIBRI_DEBUG` as equivalent to the `--debug` CLI option.

Fixes: #123