### PR TITLE
Kolibri debug take 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ in an override:
 flatpak override --env=KOLIBRI_DEBUG=1 org.endlessos.Key.Devel
 ```
 
+To enable debug logging for database queries, the
+`KOLIBRI_DEBUG_LOG_DATABASE` environment variable can be set in the same
+way as the `KOLIBRI_DEBUG` environment variable.
+
 #### Web inspector
 
 For development builds, kolibri-gnome enables WebKit developer extras. You can

--- a/README.md
+++ b/README.md
@@ -153,6 +153,13 @@ component of the project's version number.
 When Kolibri is run in debug mode, it uses debug logging for its modules
 and enables Django's debug mode. To enable Kolibri debug mode, start
 kolibri-daemon with the `KOLIBRI_DEBUG` environment variable set to `1`.
+Since the daemon is typically D-Bus activated, the best way to
+accomplish this when using the flatpak is set the environment variable
+in an override:
+
+```
+flatpak override --env=KOLIBRI_DEBUG=1 org.endlessos.Key.Devel
+```
 
 #### Web inspector
 

--- a/src/kolibri_daemon/kolibri_utils.py
+++ b/src/kolibri_daemon/kolibri_utils.py
@@ -52,11 +52,15 @@ def init_kolibri(**kwargs):
     for plugin_name in OPTIONAL_PLUGINS:
         _enable_kolibri_plugin(plugin_name, optional=True)
 
-    # Use the KOLIBRI_DEBUG environment variable for the Kolibri debug
-    # initialization value. This is basically equivalent to how "kolibri
-    # start" works.
+    # Use the KOLIBRI_DEBUG and KOLIBRI_DEBUG_LOG_DATABASE environment
+    # variables for the Kolibri debug initialization values. This is
+    # basically equivalent to how "kolibri start" works.
     if "debug" not in kwargs:
         kwargs["debug"] = getenv_as_bool("KOLIBRI_DEBUG", default=False)
+    if "debug_database" not in kwargs:
+        kwargs["debug_database"] = getenv_as_bool(
+            "KOLIBRI_DEBUG_LOG_DATABASE", default=False
+        )
 
     initialize(**kwargs)
 


### PR DESCRIPTION
After testing, I found the proper way to get the environment variables set for the daemon is `flatpak override`. While here again, I decided to add support for `KOLIBRI_DEBUG_LOG_DATABASE`.

See: #123