### PR TITLE
CI: Use os@endlessos.org as the addres for Flatpak External Data Checker

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -32,10 +32,9 @@ jobs:
         env:
           GIT_AUTHOR_NAME: Flatpak External Data Checker
           GIT_COMMITTER_NAME: Flatpak External Data Checker
-          # email sets "github-actions[bot]" as commit author, see https://github.community/t/github-actions-bot-email-address/17204/6
-          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
-          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
-          EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_AUTHOR_EMAIL: os@endlessos.org
+          GIT_COMMITTER_EMAIL: os@endlessos.org
+          EMAIL: os@endlessos.org
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: build-aux/flatpak
         run: |


### PR DESCRIPTION
Tried to make Flatpak External Data Checker's PR merged automatically before. But, it is failed and may due to the wrong mail address. Notice eos-google-chrome-app uses Flatpak External Data Checker and merges PRs automatically [1]. So, sync the mail address as os@endlessos.org with eos-google-chrome-app.

[1]: https://github.com/endlessm/eos-google-chrome-app/blob/4169d18cca057cfb88299c451a5a42da531b64a2/.github/workflows/check.yml#L18-L19