### PR TITLE
CI: Update org.endlessos.Key.Devel.metainfo.xml's folder path for appstream-util

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,4 +70,4 @@ jobs:
             --env=G_DEBUG=fatal-criticals \
             --command=appstream-util \
             org.flatpak.Builder \
-            validate flatpak_app/files/share/appdata/org.endlessos.Key.Devel.appdata.xml
+            validate flatpak_app/files/share/metainfo/org.endlessos.Key.Devel.metainfo.xml


### PR DESCRIPTION
The folder path of org.endlessos.Key.Devel.metainfo.xml has been changed to flatpak_app/files/share/metainfo. Update the CI accordingly.