### PR TITLE
ci: Use eos-shell-build token for f-e-d-c PR

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -35,7 +35,7 @@ jobs:
           GIT_AUTHOR_EMAIL: os@endlessos.org
           GIT_COMMITTER_EMAIL: os@endlessos.org
           EMAIL: os@endlessos.org
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
         working-directory: build-aux/flatpak
         run: |
           /app/flatpak-external-data-checker --update --verbose --never-fork \


### PR DESCRIPTION
The PRs created by `flatpak-external-data-checker` currently do not trigger the PR checks to run. This is because the default `GITHUB_TOKEN` used to create the PR cannot trigger a recursive GitHub Actions workflow. That's a safety measure to prevent infinitely recursing workflows.

Instead, use a personal access token (PAT) from the eos-shell-build user to create the PR. This token was created specifically for use in GitHub Actions with `repo` scope. The token has been recorded in the `WORKFLOW_TOKEN` secret.