### PR TITLE
MetaInfo: Remove screenshot caption hack

### DIFF
--- a/data/metainfo/org.endlessos.Key.metainfo.xml.in.in
+++ b/data/metainfo/org.endlessos.Key.metainfo.xml.in.in
@@ -36,27 +36,27 @@
   <launchable type="desktop-id">@FRONTEND_APPLICATION_ID@.desktop</launchable>
   <screenshots>
     <screenshot type="default">
-      <caption>1 Bring equity into the classroom; curated learning anywhere, anytime with Endless Key</caption>
+      <caption>Bring equity into the classroom; curated learning anywhere, anytime with Endless Key</caption>
       <image type="source" width="1800" height="1013">https://raw.githubusercontent.com/endlessm/endless-key-flatpak/main/data/screenshots/1-equity.png</image>
     </screenshot>
     <screenshot>
-      <caption>2 Works online and offline; access learning resources for coding, STEM, cooking, and arts &amp; crafts!</caption>
+      <caption>Works online and offline; access learning resources for coding, STEM, cooking, and arts &amp; crafts!</caption>
       <image type="source" width="1800" height="1013">https://raw.githubusercontent.com/endlessm/endless-key-flatpak/main/data/screenshots/2-offline.png</image>
     </screenshot>
     <screenshot>
-      <caption>3 Resources such as finance, healthy body, TED Ed, sports, games, arts &amp; crafts, gardening, and more</caption>
+      <caption>Resources such as finance, healthy body, TED Ed, sports, games, arts &amp; crafts, gardening, and more</caption>
       <image type="source" width="1800" height="1013">https://raw.githubusercontent.com/endlessm/endless-key-flatpak/main/data/screenshots/3-tiles.png</image>
     </screenshot>
     <screenshot>
-      <caption>4 Engaging and interactive; discover an abundance of ready-made resources, games, simulations, etc</caption>
+      <caption>Engaging and interactive; discover an abundance of ready-made resources, games, simulations, etc</caption>
       <image type="source" width="1800" height="1013">https://raw.githubusercontent.com/endlessm/endless-key-flatpak/main/data/screenshots/4-interactive.png</image>
     </screenshot>
     <screenshot>
-      <caption>5 Completely free; access without an account, safeguarded data, and no ads</caption>
+      <caption>Completely free; access without an account, safeguarded data, and no ads</caption>
       <image type="source" width="1800" height="1013">https://raw.githubusercontent.com/endlessm/endless-key-flatpak/main/data/screenshots/5-free.png</image>
     </screenshot>
     <screenshot>
-      <caption>6 Grades 5–9, 2700+ curated resources, 1500+ videos, 300+ e-books</caption>
+      <caption>Grades 5–9, 2700+ curated resources, 1500+ videos, 300+ e-books</caption>
       <image type="source" width="1800" height="1013">https://raw.githubusercontent.com/endlessm/endless-key-flatpak/main/data/screenshots/6-list.png</image>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
Not needed since the `libappstream` changes on Flathub, and explicitly discouraged by the MetaInfo quality guidelines.