### PR TITLE
Use Kolibri stable PyPI releases

### DIFF
--- a/build-aux/flatpak/modules/python3-kolibri.json
+++ b/build-aux/flatpak/modules/python3-kolibri.json
@@ -8,17 +8,17 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://github.com/learningequality/kolibri/releases/download/v0.16.0/kolibri-0.16.0-py2.py3-none-any.whl",
+            "url": "https://files.pythonhosted.org/packages/58/ad/90eb1a431e674ee15d45eec6c18f9b65c5e3222327ffd2f457fb721732af/kolibri-0.16.0-py2.py3-none-any.whl",
             "sha256": "b17003c8a0622d5695ae3d1cf09c38bfd6b63dbb7cc2e337bfb24c1d66de8f19",
             "x-checker-data": {
-                "type": "json",
-                "url": "https://api.github.com/repos/learningequality/kolibri/releases",
-                "version-query": "first | .tag_name | sub(\"^[vV]\"; \"\") | sub(\"-beta\"; \"b\")",
-                "url-query": "first | .assets[] | select(.name==\"kolibri-\" + $version + \"-py2.py3-none-any.whl\") | .browser_download_url",
+                "type": "pypi",
+                "name": "kolibri",
+                "packagetype": "bdist_wheel",
                 "versions": {
                     ">=": "0.16.0",
                     "<": "0.17.0"
-                }
+                },
+                "stable-only": true
             }
         },
         {


### PR DESCRIPTION
Now that 0.16.0 has been released, we have no reason to use Kolibri pre-releases. Switch to using PyPI and specify that only stable (non-pre-release) versions should be used. Kolibri pre-releases aren't published to PyPI, but let's be safe in case they start doing that.