### PR TITLE
ci: Turn off scheduled external data checker workflow

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,7 +1,8 @@
 name: Check for updates
 on:
-  schedule:
-    - cron: "0 * * * *" # run every hour
+  # Only allow manual run for now since no one is handling the generated PRs.
+  # schedule:
+  #   - cron: "0 * * * *" # run every hour
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
No one is processing the flatpak-external-data-checker generated PRs and they're just piling up. Disable the scheduled workflow until someone wants to take on reviewing the PRs.